### PR TITLE
Add 'Include.NON_NULL' to generated json models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
                 <containerDefaultToNull>false</containerDefaultToNull>
                 <useSpringBoot3>true</useSpringBoot3>
                 <serializableModel>true</serializableModel>
+                <additionalModelTypeAnnotations><![CDATA[@JsonInclude(JsonInclude.Include.NON_NULL)]]></additionalModelTypeAnnotations>
               </configOptions>
               <generatorName>java</generatorName>
               <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Proposing an adjustment to the OpenAPI generated classes to ignore null values on serialisation